### PR TITLE
[RwR -> develop] 신호등 이벤트 spot light 추가 및 차단바 이벤트 버그 수정

### DIFF
--- a/Assets/Retro Shaders Pro.meta
+++ b/Assets/Retro Shaders Pro.meta
@@ -1,6 +1,7 @@
 fileFormatVersion: 2
-guid: 2c040d20d8eb69a4fa85e19da5c35aee
-TextScriptImporter:
+guid: cf57125fcdcd14c4fb4aa76d801079f8
+folderAsset: yes
+DefaultImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/Assets/Scripts/Event/BoomGateEvent/BoomGateEventTrigger.cs
+++ b/Assets/Scripts/Event/BoomGateEvent/BoomGateEventTrigger.cs
@@ -9,7 +9,6 @@ public class BoomGateEventTrigger : MonoBehaviour
 {
     public EventMove EventMove;
     public GameObject target;
-    public CinemachineBrain cinemachineBrain;
     public static bool isBoomEvent = false;
     public static bool isFinished = false;
     // private Transform carCamTr;
@@ -82,7 +81,6 @@ public class BoomGateEventTrigger : MonoBehaviour
         Quaternion targetCarRotation = Quaternion.LookRotation(carTrToGate, Vector3.up);
         Vector3 targetRotation = targetCarRotation.eulerAngles;
 
-        cinemachineBrain.enabled = true;
         CameraFollow.isEvent = true;
         isBoomEvent = true;
 

--- a/Assets/Scripts/Event/BoomGateEvent/EventMove.cs
+++ b/Assets/Scripts/Event/BoomGateEvent/EventMove.cs
@@ -120,6 +120,7 @@ public class EventMove : MonoBehaviour
         {
         playerFootSteps.stop(FMOD.Studio.STOP_MODE.IMMEDIATE);
         }
+        yield return StartCoroutine(BGEvent_Lighton());
         yield return StartCoroutine(PlayerActiveOff());
         yield return new WaitForSecondsRealtime(1.0f);
         


### PR DESCRIPTION
[fix][feature][docs] Retro Shaders Pro 에셋 추가, RwR 씬을 kabocha 씬과 동기화, 플레이어 시작 위치 앞당김, 신호등 이벤트 안내 음성 시작 위치 앞당김, 신호등에 횡단보도 비추는 red / green spot light 추가, 차단바 이벤트 차단바 아래 돌기 삭제버전 추가, 차단바에 spot light 추가, 차단바 이벤트 때 플레이어 공중부양 버그 해결(base offset -0.2), fuseoff 사운드 누락 해결, 차단바 이벤트 끝날 시 헤드라이트가 켜지게 변경,  팔 오브젝트 추가