### PR TITLE
[kabocha -> develop] 엔딩 연출 수정, 일시정지 및 차량 카메라 진동 버그 수정

### DIFF
--- a/Assets/Scripts/Audio/FMODEvents.cs
+++ b/Assets/Scripts/Audio/FMODEvents.cs
@@ -55,6 +55,7 @@ public class FMODEvents : MonoBehaviour
     [field: SerializeField] public EventReference creatureDie { get; private set; }
     [field: SerializeField] public EventReference creatureBreathe { get; private set; }
     [field: SerializeField] public EventReference creatureGameOver { get; private set; }
+    [field: SerializeField] public EventReference creatureHitCar { get; private set; }
 
 
     [Header("Radio")]
@@ -91,6 +92,8 @@ public class FMODEvents : MonoBehaviour
     [field: SerializeField] public EventReference cricket2 { get; private set; }
     [field: SerializeField] public EventReference tutorialPage { get; private set; }
     [field: SerializeField] public EventReference reality { get; private set; }
+    [field: SerializeField] public EventReference endingRush { get; private set; }
+    [field: SerializeField] public EventReference toBottom { get; private set; }
 
     private void Awake()
     {

--- a/Assets/Scripts/Car/CameraFollow.cs
+++ b/Assets/Scripts/Car/CameraFollow.cs
@@ -46,14 +46,8 @@ public class CameraFollow : MonoBehaviour
         if (!CarGateEventTrigger.isCargateEvent && !isEvent)
         {
             FollowTarget();
+            CamVibrate();
         }
-        // 기존보다 훨씬 작은 값으로 시작
-        float shakeAmount = Mathf.Lerp(0.005f, 0.01f, carSpeed / 50f);
-
-        // 간단한 Perlin Noise 기반 흔들림
-        float offsetX = (Mathf.PerlinNoise(Time.time * shakeSpeed, 0f) - 0.5f) * shakeAmount;
-        float offsetY = (Mathf.PerlinNoise(0f, Time.time * shakeSpeed) - 0.5f) * shakeAmount;
-        carCam.transform.localPosition = originalPos + new Vector3(offsetX, offsetY, 0);
     }
 
     void FollowTarget()
@@ -76,6 +70,17 @@ public class CameraFollow : MonoBehaviour
         Quaternion yawRot = Quaternion.Euler(0f, currentYaw, 0f);
 
         transform.rotation = baseRot * yawRot;
+    }
+
+    void CamVibrate()
+    {
+         // 기존보다 훨씬 작은 값으로 시작
+        float shakeAmount = Mathf.Lerp(0.005f, 0.01f, carSpeed / 50f);
+
+        // 간단한 Perlin Noise 기반 흔들림
+        float offsetX = (Mathf.PerlinNoise(Time.time * shakeSpeed, 0f) - 0.5f) * shakeAmount;
+        float offsetY = (Mathf.PerlinNoise(0f, Time.time * shakeSpeed) - 0.5f) * shakeAmount;
+        carCam.transform.localPosition = originalPos + new Vector3(offsetX, offsetY, 0);
     }
 
     public void ChangeFOV()

--- a/Assets/Scripts/Car/CarController.cs
+++ b/Assets/Scripts/Car/CarController.cs
@@ -47,6 +47,8 @@ public class CarController : MonoBehaviour
     public Transform creatureCheat;
     public Transform junctionCheat;
     public Transform oakTree;
+    public Transform oakTreeCarTr;
+    public Transform oakTreeCreatureTr;
 
     public GameObject creature;
     public GameObject creatureDct;
@@ -68,13 +70,17 @@ public class CarController : MonoBehaviour
     public GameObject GPSLine;
     public GameObject chaseGPSLine;
     public GameObject AFCpanel;
+    public GameObject creaturePanel;
     WheelHit hit;
     public WheelCollider wheelCollider;
 
     public Image deerBlack;
     public Image soundFill;
     public Volume vhsVolume;
+    public Volume globalVolume;
     private VhsVol vvs;
+    private MotionBlur motionBlur;
+
     public CinemachineBrain cinemachineBrain;
 
     private int radioCh;
@@ -151,6 +157,15 @@ public class CarController : MonoBehaviour
         carRb = GetComponent<Rigidbody>();
         carRb.centerOfMass = _centerOfMass;
 
+
+        if (globalVolume != null && globalVolume.profile != null)
+        {
+            // Global Volume에서 MotionBlur 가져오기
+            if (globalVolume.profile.TryGet(out motionBlur))
+            {
+                motionBlur.intensity.Override(0.3f);
+            }
+        }
         HeadLight.SetActive(false);
 
         if (steeringWheel != null) //�ڵ�
@@ -212,15 +227,11 @@ public class CarController : MonoBehaviour
         if (GameManager.Instance.IsCargateEvent || IsBadDeath) return;
 
         disToTree = Vector3.Distance(this.transform.position, oakTree.transform.position);
-        if (disToTree < 70f && IsChased && !IsCreatureCanAttach)
-        {
-            Creature.IsRushToCar = true;
-            IsCreatureCanAttach = true;
-        }
         if (IsCanRushTree)
         {
+            IsCanRushTree = false;
             GameManager.Instance.IsRushToTree = true;
-            RushToTree();
+            StartCoroutine("RushToTree");
         }
 
         if (IsChaseEventStart)
@@ -473,6 +484,15 @@ public class CarController : MonoBehaviour
             cinemachineBrain.enabled = true;
 
             IsChaseEventStart = true;
+
+            if (globalVolume != null && globalVolume.profile != null)
+            {
+                // Global Volume에서 MotionBlur 가져오기
+                if (globalVolume.profile.TryGet(out motionBlur))
+                {
+                    motionBlur.intensity.Override(1f);
+                }
+            }
             gravel.stop(STOP_MODE.IMMEDIATE);
             EventManager.Instance.SetEvent(1);
             EventManager.Instance.PlayEvent();
@@ -498,6 +518,13 @@ public class CarController : MonoBehaviour
         if (col.gameObject.CompareTag("TunnelNavi"))
         {
             AudioManager.Instance.PlayOneShot(FMODEvents.instance.tunnel, this.transform.position);
+            Destroy(col.gameObject);
+        }
+        if (col.gameObject.CompareTag("Ending") && IsChased && !IsCreatureCanAttach)
+        {
+            IsCanRushTree = true;
+            Creature.IsRushToCar = true;
+            IsCreatureCanAttach = true;
             Destroy(col.gameObject);
         }
     }
@@ -530,17 +557,6 @@ public class CarController : MonoBehaviour
                 carDrive.stop(STOP_MODE.IMMEDIATE);
                 gravel.stop(STOP_MODE.IMMEDIATE);
             }
-            else
-            {
-                IsCanRushTree = true;
-            }
-        }
-        if (col.gameObject.CompareTag("Oak") && IsChased)
-        {
-            IsCanRushTree = false;
-            chaseBackground.stop(STOP_MODE.IMMEDIATE);
-            EventManager.Instance.SetEvent(2);
-            EventManager.Instance.PlayEvent();
         }
         if (col.gameObject.CompareTag("Tree") && IsWrongWay)
         {
@@ -731,7 +747,7 @@ public class CarController : MonoBehaviour
 
         yield return new WaitForSeconds(4.5f);
         this.transform.position = new Vector3(2753f, 462f, -2859f);
-        this.transform.rotation = Quaternion.Euler(new Vector3(351.025787f,117.775482f,354.717651f));
+        this.transform.rotation = Quaternion.Euler(new Vector3(351.025787f, 117.775482f, 354.717651f));
         AFCpanel.SetActive(false);
         creatureDct.SetActive(true);
     }
@@ -832,7 +848,6 @@ public class CarController : MonoBehaviour
         carDrive.stop(STOP_MODE.ALLOWFADEOUT);
         gravel.stop(STOP_MODE.IMMEDIATE);
         HeadLight.SetActive(false);
-        //carRb.isKinematic = true;
     }
 
     public void CreatureReveal()
@@ -859,23 +874,28 @@ public class CarController : MonoBehaviour
         StartCoroutine("WarnTextEffect");
     }
 
-    public void RushToTree()
+    IEnumerator RushToTree()
     {
-        Creature.IsAttachCar = true;
         if (!IsRushTreeStart)
         {
             IsRushTreeStart = true;
             carRb.isKinematic = false;
-            AudioManager.Instance.PlayOneShot(FMODEvents.instance.creatureAttach, this.transform.position);
         }
-        this.transform.position = Vector3.MoveTowards(transform.position, oakTree.position, 20f * Time.deltaTime);
-        float distance = Vector3.Distance(transform.position, oakTree.position);
-        if (distance < 5f && !IsCreatureOut)
-        {
-            Creature.IsAttachCar = false;
-            IsCreatureOut = true;
-            AudioManager.Instance.PlayOneShot(FMODEvents.instance.carSliding, this.transform.position);
-        }
+        yield return new WaitForSeconds(0.5f);
+        creaturePanel.SetActive(true);
+        chaseGPSLine.SetActive(false);
+        AudioManager.Instance.PlayOneShot(FMODEvents.instance.endingRush, this.transform.position);
+        yield return new WaitForSeconds(6f);
+        Creature.IsAttachCar = false;
+        this.transform.position = oakTreeCarTr.position;
+        creature.transform.position = oakTreeCreatureTr.position;
+
+        creaturePanel.SetActive(false);
+        IsCanRushTree = false;
+        gravel.stop(STOP_MODE.IMMEDIATE);
+        chaseBackground.stop(STOP_MODE.IMMEDIATE);
+        EventManager.Instance.SetEvent(2);
+        EventManager.Instance.PlayEvent();
     }
 
     IEnumerator WarnTextEffect()
@@ -938,10 +958,5 @@ public class CarController : MonoBehaviour
         AudioManager.Instance.PlayOneShot(FMODEvents.instance.chaseReNavi, this.transform.position);
         yield return new WaitForSeconds(3.6f);
         chaseGPSLine.SetActive(true);
-    }
-
-    public void CarFmodPause()
-    {
-
     }
 }

--- a/Assets/Scripts/Event/CreatureEvent/Creature.cs
+++ b/Assets/Scripts/Event/CreatureEvent/Creature.cs
@@ -61,7 +61,7 @@ public class Creature : MonoBehaviour
         {
             navMeshAgent.enabled = false;
         }
-        if (!IsGameOver && IsChase && !IsAttachCar)
+        if (!IsGameOver && IsChase && !IsAttachCar && !IsRushToCar)
         {
             IsReveal = false;
             NavCheck();
@@ -69,7 +69,6 @@ public class Creature : MonoBehaviour
             ReSpawn();
         }
         LookTarget();
-
         if (IsReveal)
         {
             anim.SetBool("IsRun2", true);
@@ -87,14 +86,8 @@ public class Creature : MonoBehaviour
         {
             IsTeleport = true;
             navMeshAgent.enabled = false;
-
-            float ranX = Random.Range(-15, 15);
-            float ranZ = Random.Range(-15, 15);
-
-            Vector3 targetPos = new Vector3(targetTr.position.x - ranX, targetTr.position.y + 5f, targetTr.position.z - ranZ);
-            this.transform.position = targetPos;
-            navMeshAgent.enabled = true;
-            navMeshAgent.speed = 50f;
+            SetRushPositionEnd();
+            StartCoroutine("JumpToCarEnd");
         }
         
         if (IsAttachCar && !GameManager.Instance.IsEnding)
@@ -165,8 +158,9 @@ public class Creature : MonoBehaviour
                 EventManager.Instance.PlayEvent();
                 stepEmitter.Stop();
             }
-            else if(!IsGameOver && IsRushToCar)
+            else if(!IsGameOver && IsRushToCar && !IsAttachCar)
             {
+                AudioManager.Instance.PlayOneShot(FMODEvents.instance.creatureHitCar, targetTr.position);
                 IsAttachCar = true;
             }
         }
@@ -210,6 +204,26 @@ public class Creature : MonoBehaviour
         col.isTrigger = true;
         Vector3 offset = targetTr.forward * 35f + targetTr.up * -6f;
         this.transform.position = targetTr.position + offset;
+    }
+
+    public void SetRushPositionEnd()
+    {
+        rb.isKinematic = false;
+        col.isTrigger = true;
+        Vector3 offset = targetTr.forward * 15f + targetTr.up * 3f;
+        this.transform.position = targetTr.position + offset;
+        AudioManager.Instance.PlayOneShot(FMODEvents.instance.creatureGameOver, targetTr.position);
+    }
+
+    IEnumerator JumpToCarEnd()
+    {
+        LookTarget();
+        rb.isKinematic = true;
+        col.isTrigger = false;
+        yield return new WaitForSeconds(0.5f);
+        AudioManager.Instance.PlayOneShot(FMODEvents.instance.creatureHitCar, targetTr.position);
+        anim.SetBool("IsAttack", true);
+        IsAttachCar = true;
     }
 
     public void Die()

--- a/Assets/Scripts/Event/TrafficLightEvent/TLRadioSound.cs
+++ b/Assets/Scripts/Event/TrafficLightEvent/TLRadioSound.cs
@@ -16,7 +16,6 @@ public class TLRadioSound : MonoBehaviour
     void OnTriggerEnter(Collider collider){
         if (collider.gameObject.CompareTag("Car")){
         AudioManager.Instance.PlayOneShot(FMODEvents.instance.radio_TL, this.transform.position);
-
         this.gameObject.SetActive(false);
     }
     }

--- a/Assets/Scripts/Manager/PauseGame.cs
+++ b/Assets/Scripts/Manager/PauseGame.cs
@@ -26,6 +26,7 @@ public class PauseGame : MonoBehaviour
         AudioManager.Instance.PauseOn();
         pausePanel.SetActive(true);
         buttons.SetActive(true);
+        Cursor.visible = true;
         gameScale = 0;
     }
 
@@ -35,6 +36,7 @@ public class PauseGame : MonoBehaviour
         AudioManager.Instance.PauseOff();
         pausePanel.SetActive(false);
         buttons.SetActive(false);
+        Cursor.visible = false;
         gameScale = 1;
     }
 
@@ -42,6 +44,7 @@ public class PauseGame : MonoBehaviour
     {
         GameManager.Instance.IsGamePaused = false;
         gameScale = 1;
+        Cursor.visible = true;
         SceneManager.LoadScene("Title");
     }
 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -24,6 +24,7 @@ TagManager:
   - TunnelNavi
   - Gravel
   - Grass
+  - Ending
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
1. 엔딩 연출 수정
  - 추격전 이후 엔딩 연출 수정

2. 일시정지, 차량 카메라 진동 버그 수정
  - 일시정지 메뉴에서 마우스 커서 안보이는 버그 수정
  - 차량 카메라 진동이 차단바 이벤트에서는 작동 안되도록 수정 