### PR TITLE
[kabocha -> develop] 차단바 이후 게임오버 연출 수정

### DIFF
--- a/Assets/Scripts/Car/CarController.cs
+++ b/Assets/Scripts/Car/CarController.cs
@@ -748,7 +748,9 @@ public class CarController : MonoBehaviour
         yield return new WaitForSeconds(4.5f);
         this.transform.position = new Vector3(2753f, 462f, -2859f);
         this.transform.rotation = Quaternion.Euler(new Vector3(351.025787f, 117.775482f, 354.717651f));
+
         AFCpanel.SetActive(false);
+        yield return new WaitForSeconds(3.0f);
         creatureDct.SetActive(true);
     }
     IEnumerator SoundLoudWarn()


### PR DESCRIPTION
1. 차단바 이후 게임오버 연출 수정
  - 화면 전환 이후 "3초"의 텀 이후 크리처의 점프스케어 시작하는 방식으로 연출 수정