### PR TITLE
[kabocha -> develop] 엔딩에서 다시 시작점으로 이동 시 차량 윈도우, 바디 복구

### DIFF
--- a/Assets/Scripts/Car/CarController.cs
+++ b/Assets/Scripts/Car/CarController.cs
@@ -25,6 +25,8 @@ public class CarController : MonoBehaviour
         public WheelCollider wheelCollider;
         public Axel axel;
     }
+    public static Action resetWindow;
+    
     public float maxAcceleration = 30.0f;
     public float brakeAcceleration = 50.0f;
     public float turnSensitivity = 1.0f;
@@ -144,6 +146,11 @@ public class CarController : MonoBehaviour
 
         wind = AudioManager.Instance.CreateInstance(FMODEvents.instance.wind);
         gravel = AudioManager.Instance.CreateInstance(FMODEvents.instance.gravel);
+
+        resetWindow = () =>
+        {
+            ResetWindow();
+        };
     }
 
     void Start()
@@ -960,5 +967,11 @@ public class CarController : MonoBehaviour
         AudioManager.Instance.PlayOneShot(FMODEvents.instance.chaseReNavi, this.transform.position);
         yield return new WaitForSeconds(3.6f);
         chaseGPSLine.SetActive(true);
+    }
+
+    public void ResetWindow()
+    {
+        brokenBody.SetActive(false);
+        originBody.SetActive(true);   
     }
 }

--- a/Assets/Scripts/Event/CreatureEvent/GameEndFade.cs
+++ b/Assets/Scripts/Event/CreatureEvent/GameEndFade.cs
@@ -28,6 +28,8 @@ public class GameEndFade : MonoBehaviour
         AudioManager.Instance.PlayOneShot(FMODEvents.instance.reality,car.transform.position);
         car.transform.position = startTr.position;
         car.transform.rotation = startTr.rotation;
+        
+        CarController.resetWindow();
 
         yield return new WaitForSeconds(1.68f);
         fadeImage.gameObject.SetActive(false);

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -138,7 +138,8 @@ PlayerSettings:
   vulkanEnableCommandBufferRecycling: 1
   loadStoreDebugModeEnabled: 0
   bundleVersion: 1.0
-  preloadedAssets: []
+  preloadedAssets:
+  - {fileID: 11400000, guid: 6d9ba37cb6a5fdb42aee66133ebc873e, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
1. 엔딩에서 다시 시작점으로 이동 시 차량 윈도우, 바디 복구
- 깨진 유리창 -> 안깨진 유리창